### PR TITLE
Bugfix: Segments created in X-ray as parent

### DIFF
--- a/sdk/src/main/java/com/amazonaws/xray/opentelemetry/tracing/RecorderBackedTracer.java
+++ b/sdk/src/main/java/com/amazonaws/xray/opentelemetry/tracing/RecorderBackedTracer.java
@@ -38,13 +38,12 @@ public class RecorderBackedTracer implements Tracer {
   }
 
   /**
-   * {@inheritDoc}
-   * This implementation will automatically update the active span based on changes to the X-Ray
-   * recorder but otherwise conforms to OpenTelemetry semantics when creating spans.
+   * {@inheritDoc} This implementation will automatically update the active span based on changes to
+   * the X-Ray recorder but otherwise conforms to OpenTelemetry semantics when creating spans.
    */
   @Override
   public Span getCurrentSpan() {
-    if (currentSpan == null) {
+    if (currentSpan == null && recorder.getTraceEntity() == null) {
       return DefaultSpan.getInvalid();
     } else {
       //Reflect the recorder's current entity changing in response to X-Ray calls


### PR DESCRIPTION
*Issue #, if available:*
No issue filed, discovered this doing some unrelated refactoring.

*Description of changes:*

* Reflect the creation of a trace entity via the X-Ray SDK as the active span in OT

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
